### PR TITLE
Add NetScope-Lite front‑end tool

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,55 @@
+function netscope() {
+    return {
+        subnet: localStorage.getItem('netscope-subnet') || '192.168.1',
+        hosts: [],
+        darkMode: localStorage.getItem('netscope-dark') === 'true',
+        init() {
+            if (this.darkMode) document.documentElement.classList.add('dark');
+        },
+        toggleDark() {
+            this.darkMode = !this.darkMode;
+            localStorage.setItem('netscope-dark', this.darkMode);
+            document.documentElement.classList.toggle('dark', this.darkMode);
+        },
+        scan() {
+            localStorage.setItem('netscope-subnet', this.subnet);
+            this.hosts = [];
+            for (let i = 1; i <= 254; i++) {
+                const ip = `${this.subnet}.${i}`;
+                const host = { ip, status: 'pending', note: localStorage.getItem('note-' + ip) || '' };
+                this.hosts.push(host);
+                this.pingHost(host);
+            }
+        },
+        pingHost(host) {
+            const img = new Image();
+            const timeout = setTimeout(() => {
+                host.status = 'offline';
+            }, 3000);
+            img.onload = () => {
+                clearTimeout(timeout);
+                host.status = 'online';
+            };
+            img.onerror = () => {
+                clearTimeout(timeout);
+                host.status = 'offline';
+            };
+            img.src = `http://${host.ip}/favicon.ico?` + Date.now();
+        },
+        saveNote(host) {
+            localStorage.setItem('note-' + host.ip, host.note);
+        },
+        exportCSV() {
+            const header = ['IP Address','Status','Note'];
+            const rows = this.hosts.map(h => [h.ip, h.status, h.note]);
+            let csvContent = 'data:text/csv;charset=utf-8,' + [header, ...rows].map(e => e.join(',')).join('\n');
+            const encodedUri = encodeURI(csvContent);
+            const link = document.createElement('a');
+            link.setAttribute('href', encodedUri);
+            link.setAttribute('download', 'netscope.csv');
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NetScope-Lite</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 text-gray-900 p-4" x-data="netscope()" x-init="init()" :class="{'dark': darkMode}">
+    <div class="container mx-auto">
+        <div class="flex justify-between items-center mb-4">
+            <h1 class="text-2xl font-bold">NetScope-Lite</h1>
+            <button @click="toggleDark()" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded">Toggle Theme</button>
+        </div>
+        <div class="mb-4">
+            <label class="block mb-2 font-semibold">Subnet (/24)</label>
+            <input type="text" x-model="subnet" class="w-full p-2 border rounded" placeholder="192.168.1">
+            <button @click="scan()" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Start Scan</button>
+            <button @click="exportCSV()" class="mt-2 ml-2 px-4 py-2 bg-green-500 text-white rounded">Export CSV</button>
+        </div>
+        <table class="min-w-full bg-white dark:bg-gray-800">
+            <thead>
+                <tr>
+                    <th class="px-4 py-2">IP Address</th>
+                    <th class="px-4 py-2">Status</th>
+                    <th class="px-4 py-2">Note</th>
+                </tr>
+            </thead>
+            <tbody>
+                <template x-for="host in hosts" :key="host.ip">
+                    <tr>
+                        <td class="border px-4 py-2" x-text="host.ip"></td>
+                        <td class="border px-4 py-2">
+                            <span x-show="host.status === 'online'" class="text-green-600">Online</span>
+                            <span x-show="host.status === 'offline'" class="text-red-600">Offline</span>
+                            <span x-show="host.status === 'pending'" class="text-gray-500">...</span>
+                        </td>
+                        <td class="border px-4 py-2">
+                            <input type="text" class="w-full p-1 border rounded" x-model="host.note" @change="saveNote(host)">
+                        </td>
+                    </tr>
+                </template>
+            </tbody>
+        </table>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add lightweight NetScope-Lite interface using Tailwind and Alpine.js
- implement JS subnet scanner with simple ping via image requests
- store notes in localStorage and allow CSV export
- include dark mode toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a858a73f883329cc263ff7acb7019