### PR TITLE
Improve dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,19 +7,19 @@
     <title>NetScope-Lite</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 text-gray-900 p-4" x-data="netscope()" x-init="init()" :class="{'dark': darkMode}">
+<body class="bg-gray-100 text-gray-900 p-4 dark:bg-gray-900 dark:text-white" x-data="netscope()" x-init="init()" :class="{'dark': darkMode}">
     <div class="container mx-auto">
         <div class="flex justify-between items-center mb-4">
             <h1 class="text-2xl font-bold">NetScope-Lite</h1>
-            <button @click="toggleDark()" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded">Toggle Theme</button>
+            <button @click="toggleDark()" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 dark:text-white rounded">Toggle Theme</button>
         </div>
         <div class="mb-4">
             <label class="block mb-2 font-semibold">Subnet (/24)</label>
-            <input type="text" x-model="subnet" class="w-full p-2 border rounded" placeholder="192.168.1">
+            <input type="text" x-model="subnet" class="w-full p-2 border rounded dark:bg-gray-800 dark:border-gray-700 dark:text-white" placeholder="192.168.1">
             <button @click="scan()" class="mt-2 px-4 py-2 bg-blue-500 text-white rounded">Start Scan</button>
             <button @click="exportCSV()" class="mt-2 ml-2 px-4 py-2 bg-green-500 text-white rounded">Export CSV</button>
         </div>
-        <table class="min-w-full bg-white dark:bg-gray-800">
+        <table class="min-w-full bg-white dark:bg-gray-800 dark:text-white rounded shadow">
             <thead>
                 <tr>
                     <th class="px-4 py-2">IP Address</th>
@@ -37,7 +37,7 @@
                             <span x-show="host.status === 'pending'" class="text-gray-500">...</span>
                         </td>
                         <td class="border px-4 py-2">
-                            <input type="text" class="w-full p-1 border rounded" x-model="host.note" @change="saveNote(host)">
+                            <input type="text" class="w-full p-1 border rounded dark:bg-gray-800 dark:border-gray-700 dark:text-white" x-model="host.note" @change="saveNote(host)">
                         </td>
                     </tr>
                 </template>


### PR DESCRIPTION
## Summary
- ensure dark mode uses white text on dark backgrounds
- adjust input and table styling to look professional

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a86aad2cc8332ae42ff8ff493a1ac